### PR TITLE
カラースキームを外側から定義できるように

### DIFF
--- a/lib/Devel/KYTProf.pm
+++ b/lib/Devel/KYTProf.pm
@@ -13,6 +13,11 @@ __PACKAGE__->mk_classdata( logger => undef );
 __PACKAGE__->mk_classdata( threshold => undef );
 __PACKAGE__->mk_classdata( st_sql => {} ); # for DBI
 
+__PACKAGE__->mk_classdata( color_time   => 'red' );
+__PACKAGE__->mk_classdata( color_module => 'cyan' );
+__PACKAGE__->mk_classdata( color_info   => 'blue' );
+__PACKAGE__->mk_classdata( color_call   => 'green' );
+
 use UNIVERSAL::require;
 use Time::HiRes;
 use Term::ANSIColor;
@@ -92,18 +97,6 @@ use Term::ANSIColor;
     );
 };
 
-my %color = (
-    'time'   => 'red',
-    'module' => 'cyan',
-    'info'   => 'blue',
-    'call'   => 'green',
-);
-
-sub import {
-    my ($class, %opts) = @_;
-    %color = (%color, %{$opts{color}||{}});
-}
-
 sub add_profs {
     my ($class, $module, $methods, $callback) = @_;
     $module->require; # or warn $@ and return;
@@ -168,11 +161,11 @@ sub add_prof {
         my $ns = Time::HiRes::tv_interval($start) * 1000;
         if (!$threshold || $ns >= $threshold) {
             my $message = "";
-            $message .= colored(sprintf('% 9.3f ms ', $ns), $color{'time'});
-            $message .= colored(sprintf(' [%s] ', ref $_[0] || $_[0] || ''), $color{'module'});
-            $message .= colored(sprintf(' %s ', $callback ? $callback->($orig, @_) || '' : $method || ''), $color{info});
+            $message .= colored(sprintf('% 9.3f ms ', $ns), $class->color_time);
+            $message .= colored(sprintf(' [%s] ', ref $_[0] || $_[0] || ''), $class->color_module);
+            $message .= colored(sprintf(' %s ', $callback ? $callback->($orig, @_) || '' : $method || ''), $class->color_info);
             $message .= ' | ';
-            $message .= colored(sprintf('%s:%d', $package || '', $line || 0), $color{call});
+            $message .= colored(sprintf('%s:%d', $package || '', $line || 0), $class->color_call);
             $message .= "\n";
             $class->logger ? $class->logger->log(
                 level   => 'debug',


### PR DESCRIPTION
はじめましてnekokakです
KYTProf大変便利につかわせていただいています。

表示されるメッセージの色付けなのですが
私の端末だとblueが凄く見難くなってしまうので、外側から別で定義できればとてもありがたいです。

適当に変更いれてみてますが、もしよろしければとりこんでやってください。
適当なので他の方法でもOKです！

よろしくお願いしまーす
