### PR TITLE
furl support by default

### DIFF
--- a/lib/Devel/KYTProf.pm
+++ b/lib/Devel/KYTProf.pm
@@ -113,6 +113,17 @@ use Term::ANSIColor;
     );
 };
 
+'Furl::HTTP'->require and do {
+    __PACKAGE__->add_prof(
+        'Furl::HTTP',
+        'request',
+        sub {
+            my($orig, $self, %args) = @_;
+            return sprintf '%s %s', $args{method}, $args{url};
+        },
+    );
+};
+
 sub add_profs {
     my ($class, $module, $methods, $callback) = @_;
     $module->require; # or warn $@ and return;


### PR DESCRIPTION
Furlサポートが標準で欲しかったので、つけてみました。

どのメソッドも最終的にはFurl::HTTP#requestを呼ぶので、それだけをadd_profしてます。

よろしくお願いします。
