### PR TITLE
Fix for multiple use.

### DIFF
--- a/lib/Devel/KYTProf.pm
+++ b/lib/Devel/KYTProf.pm
@@ -4,6 +4,8 @@ use warnings;
 
 our $VERSION = '0.9991';
 
+my $Applied = {};
+
 use Class::Data::Lite (
     rw => {
         namespace_regex         => undef,
@@ -50,6 +52,7 @@ sub apply_prof {
     unless ($prof_pkg->can('apply')) {
         die qq{"$prof_pkg" has no `apply` method. A profiler package should implement it.\n};
     }
+    return if ++$Applied->{$prof_pkg} > 1; # skip if already applied
     $prof_pkg->apply(@args);
 }
 

--- a/t/dbi.t
+++ b/t/dbi.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use Test::More;
 use Devel::KYTProf;
+use Devel::KYTProf; # test for multiple applied problem
 
 use Test::Requires 'DBI', 'DBD::SQLite';
 


### PR DESCRIPTION
Hi.

This PR ensures to apply_prof() called only once per profiler package.
When `use Devel::KYTProf` called multiple times, Profiler::DBI fails tests as below.

```console
t/dbi.t ...................... 1/?
#   Failed test at t/dbi.t line 29.
#                   'Use of uninitialized value in sprintf at /Users/fujiwara/src/github.com/fujiwara/perl5-devel-kytprof/.build/oJfbj5NQ/blib/lib/Devel/KYTProf.pm line 140.
# Use of uninitialized value in sprintf at /Users/fujiwara/src/github.com/fujiwara/perl5-devel-kytprof/.build/oJfbj5NQ/blib/lib/Devel/KYTProf.pm line 140.
#     0.251 ms  [DBI::st]    (1 rows)  | main:27
# '
#     doesn't match '(?^:\[DBI::st\]  insert into mock \(id, name\) values \(\?,\?\) \(bind: 1, nekokak\) \(1 rows\)  \|)'

#   Failed test at t/dbi.t line 44.
#                   'Use of uninitialized value in sprintf at /Users/fujiwara/src/github.com/fujiwara/perl5-devel-kytprof/.build/oJfbj5NQ/blib/lib/Devel/KYTProf.pm line 140.
# Use of uninitialized value in sprintf at /Users/fujiwara/src/github.com/fujiwara/perl5-devel-kytprof/.build/oJfbj5NQ/blib/lib/Devel/KYTProf.pm line 140.
#     0.075 ms  [DBI::st]    (1 rows)  | main:42
# '
#     doesn't match '(?^:\[DBI::st\]  insert into mock \(id, name\) values \(\?,\?\) \(bind: 2, onishi\) \(1 rows\)  \|)'
# Looks like you failed 2 tests of 2.
```