### PR TITLE
Add no warnings

### DIFF
--- a/lib/Devel/KYTProf.pm
+++ b/lib/Devel/KYTProf.pm
@@ -140,6 +140,7 @@ sub add_prof {
             if ($callback) {
                 my $v = $callback->($orig, @_);
                 if (ref $v eq "ARRAY") {
+                    no warnings;
                     $cb_info = sprintf $v->[0], map { $v->[2]->{$_} } @{$v->[1]};
                     $cb_data = $v->[2];
                 } else {

--- a/t/warning.t
+++ b/t/warning.t
@@ -1,0 +1,38 @@
+use strict;
+use warnings;
+use Test::More;
+use Devel::KYTProf;
+
+Devel::KYTProf->add_prof(
+    'Mock',
+    'foo',
+    sub {
+        return [
+            'alarm here (%s/%d)',
+            ['string', 'number'],
+            {
+                string => undef,
+                number => undef,
+            },
+        ];
+    }
+);
+
+{
+    my $buffer = '';
+    open my $fh, '>', \$buffer or die "Could not open in-memory buffer";
+    *STDERR = $fh;
+
+    Mock->foo;
+
+    unlike $buffer, qr/Use of uninitialized value in sprintf/;
+    like $buffer, qr/alarm here \(\/0\)/;
+
+    close $fh;
+}
+
+done_testing;
+
+package Mock;
+
+sub foo {'foo'}


### PR DESCRIPTION
In our environments, Devel::KYTProf outputs some warning message: `Use of uninitialized value in sprintf ...`
Because, `sprintf` may receive `undef` line 143.

So, I added `no warnings;` and I make a warning message not occur.
What do you think this pull request?