### PR TITLE
When url or method is undefined, profiler outputs warning message

### DIFF
--- a/lib/Devel/KYTProf/Profiler/Furl/HTTP.pm
+++ b/lib/Devel/KYTProf/Profiler/Furl/HTTP.pm
@@ -8,13 +8,32 @@ sub apply {
         'Furl::HTTP',
         'request',
         sub {
-            my($orig, $self, %args) = @_;
+            my ($orig, $self, %args) = @_;
+
+            my $method = $args{method} || 'GET';
+            my $url = do {
+                if (defined $args{url}) {
+                    $args{url};
+                } else {
+                    my $scheme = $args{scheme} || 'http';
+                    my $port = $args{port} || '';
+                    my $host = $args{host} || '';
+                    my $path_query = $args{path_query} || '';
+                    sprintf('%s://%s%s%s',
+                        $scheme,
+                        $host,
+                        $port ? ":$port" : '',
+                        substr($path_query, 0, 1) eq '/' ? $path_query : "/$path_query",
+                    );
+                }
+            };
+
             return [
                 '%s %s',
                 ['http_method', 'http_url'],
                 {
-                    http_method => $args{method},
-                    http_url => $args{url},
+                    http_method => $method,
+                    http_url    => $url,
                 },
             ];
         },

--- a/lib/Devel/KYTProf/Profiler/Furl/HTTP.pm
+++ b/lib/Devel/KYTProf/Profiler/Furl/HTTP.pm
@@ -13,7 +13,7 @@ sub build_url {
     my $host = $args{host} || '';
     my $path_query = $args{path_query} || '';
 
-    return sprintf('%s://%s%s%s', $scheme, $host, $port, substr($args{path_query}, 0, 1) eq '/' ? $path_query : "/$path_query");
+    return sprintf('%s://%s%s%s', $scheme, $host, $port ? ":$port" : '', substr($path_query, 0, 1) eq '/' ? $path_query : "/$path_query");
 }
 
 sub apply {

--- a/lib/Devel/KYTProf/Profiler/Furl/HTTP.pm
+++ b/lib/Devel/KYTProf/Profiler/Furl/HTTP.pm
@@ -3,6 +3,19 @@ package Devel::KYTProf::Profiler::Furl::HTTP;
 use strict;
 use warnings;
 
+sub build_url {
+    my (%args) = @_;
+
+    return $args{url} if defined $args{url};
+
+    my $scheme = $args{scheme} || 'http';
+    my $port = $args{port} || '';
+    my $host = $args{host} || '';
+    my $path_query = $args{path_query} || '';
+
+    return sprintf('%s://%s%s%s', $scheme, $host, $port, substr($args{path_query}, 0, 1) eq '/' ? $path_query : "/$path_query");
+}
+
 sub apply {
     Devel::KYTProf->add_prof(
         'Furl::HTTP',
@@ -11,22 +24,7 @@ sub apply {
             my ($orig, $self, %args) = @_;
 
             my $method = $args{method} || 'GET';
-            my $url = do {
-                if (defined $args{url}) {
-                    $args{url};
-                } else {
-                    my $scheme = $args{scheme} || 'http';
-                    my $port = $args{port} || '';
-                    my $host = $args{host} || '';
-                    my $path_query = $args{path_query} || '';
-                    sprintf('%s://%s%s%s',
-                        $scheme,
-                        $host,
-                        $port ? ":$port" : '',
-                        substr($path_query, 0, 1) eq '/' ? $path_query : "/$path_query",
-                    );
-                }
-            };
+            my $url = build_url(%args);
 
             return [
                 '%s %s',


### PR DESCRIPTION
`Devel::KYTProf::Profiler::Furl::HTTP` requires `method` and `url` parameter. But, we can call `Furl::HTTP#request` by other parameters: `scheme`, `host`, `port` and `query_parameter`
In the latter case, Devel::KYTProf::Profiler::Furl::HTTP outputs warning message because `method` and `url` are undefined.