### PR TITLE
add db name to DBI trace

### DIFF
--- a/lib/Devel/KYTProf/Profiler/DBI.pm
+++ b/lib/Devel/KYTProf/Profiler/DBI.pm
@@ -23,10 +23,13 @@ sub apply {
 
     my $LastSQL;
     my $LastBinds;
+    my $LastDBName;
     my $IsInProf;
 
     our $_TRACER = DBIx::Tracer->new(sub {
         my %args = @_;
+        $LastDBName = $args{dbh}->{Name};
+        $LastDBName = '' unless defined $LastDBName;
         $LastSQL = $args{sql};
         my $bind_params = $args{bind_params} || [];
         $LastBinds = scalar(@$bind_params) ?
@@ -39,12 +42,13 @@ sub apply {
         sub {
             my (undef, $sth) = @_;
             return [
-                '%s %s (%d rows)',
-                ['sql', 'sql_binds', 'rows'],
+                '(db:%s) %s %s (%d rows)',
+                ['database', 'sql', 'sql_binds', 'rows'],
                 {
                     sql       => $LastSQL,
                     sql_binds => $LastBinds,
                     rows      => $sth->rows,
+                    database  => $LastDBName,
                 },
             ];
         },
@@ -57,11 +61,12 @@ sub apply {
         sub {
             undef $IsInProf;
             return [
-                '%s %s',
-                ['sql', 'sql_binds'],
+                '(db:%s) %s %s',
+                ['database', 'sql', 'sql_binds'],
                 {
                     sql       => $LastSQL,
                     sql_binds => $LastBinds,
+                    database  => $LastDBName,
                 },
             ];
         },

--- a/t/dbi.t
+++ b/t/dbi.t
@@ -12,7 +12,7 @@ my $buffer = '';
 open my $fh, '>', \$buffer or die "Could not open in-memory buffer";
 *STDERR = $fh;
 
-my $dbi = DBI->connect('dbi:SQLite:','','');
+my $dbi = DBI->connect('dbi:SQLite:testdb','','');
 
 $dbi->do(q{create table mock (id integer, name text, primary key ( id ))});
 
@@ -26,7 +26,7 @@ close $fh;
     my $sth = $dbi->prepare('insert into mock (id, name) values (?,?)');
     $sth->execute(1,'nekokak');
 
-    like $buffer, qr/\[DBI::st\]  insert into mock \(id, name\) values \(\?,\?\) \(bind: 1, nekokak\) \(1 rows\)  \|/;
+    like $buffer, qr/\[DBI::st\]  \(db:testdb\) insert into mock \(id, name\) values \(\?,\?\) \(bind: 1, nekokak\) \(1 rows\)  \|/;
 
     close $fh;
 }
@@ -41,7 +41,7 @@ close $fh;
     $sth->bind_param(2, 'onishi');
     $sth->execute;
 
-    like $buffer, qr/\[DBI::st\]  insert into mock \(id, name\) values \(\?,\?\) \(bind: 2, onishi\) \(1 rows\)  \|/;
+    like $buffer, qr/\[DBI::st\]  \(db:testdb\) insert into mock \(id, name\) values \(\?,\?\) \(bind: 2, onishi\) \(1 rows\)  \|/;
 
     close $fh;
 }


### PR DESCRIPTION
Our team use Devel::KYTProf via [Devel::KYTProf::Logger::XRay](https://github.com/fujiwara/Devel-KYTProf-Logger-XRay) to get traces of some RPCs and put them to AWS X-Ray.

In general case, we, user of AWS X-Ray, may see some traces of some services and traces are distinguished by their name.

Currently Devel::KYTProf::Logger::XRay use tracer module name as (sub)segments' name such as DBI or LWP::UserAgent.
If some services use Devel::KYTProf::Logger::XRay to put traces to AWS X-Ray, traces that may indicate different host are named `DBI`, thus, we cannot distinguish them 😫 

![image](https://user-images.githubusercontent.com/87649/71515664-dbe51000-28e7-11ea-9c60-5cdf22e3345b.png)

If Devel::KYTProf::Profiler::DBI holds connected DB name, we can use it for (sub)segment name.